### PR TITLE
Add download options to improve download speed

### DIFF
--- a/download-options.css
+++ b/download-options.css
@@ -1,0 +1,131 @@
+body.download-options {
+    position: relative;
+    user-select: text;
+    width: auto;
+    height: auto;
+    padding: 14px;
+}
+
+.download-options > .title {
+    font-size: 28px;
+    margin: 0;
+}
+
+.download-options > button {
+    width: 320px;
+}
+
+.options-section {
+    margin: 10px 0 16px;
+}
+
+.options-section > div {
+    font-size: 18px;
+    margin: 14px 0;
+    vertical-align: middle;
+}
+
+.options-section label {
+    cursor: pointer;
+}
+
+.options-section input[type="radio"] {
+    vertical-align: middle;
+    appearance: none;
+    margin: -2px 0 0 6px;
+    border: 1px solid pink;
+    border-radius: 50%;
+    width: 17px;
+    height: 17px;
+    cursor: pointer;
+    transition: background 0.1s;
+}
+
+.options-section input[type="radio"]:checked {
+    background: pink;
+}
+
+.options-section input[type="text"] {
+    width: 65%;
+    font-size: 18px;
+    padding: 6px;
+    border: 2px solid #212121;
+    border-radius: 4px;
+    color: white;
+    background-color: #212121;
+}
+
+.options-section input[type="text"]::placeholder {
+    color: #e0e0e0;
+    font-style: italic;
+}
+
+.options-section input[type="text"]:focus {
+    border-color: #ffd54f;
+    outline: none;
+}
+
+.caution {
+    position: relative;
+    display: inline-block;
+    text-align: center;
+    vertical-align: middle;
+    margin: -3px 0 0 4px;
+    min-width: 24px;
+    height: 24px;
+    padding: 0;
+}
+
+.caution:hover {
+    --pink-btn-bg1: #953050;
+    --pink-btn-bg2: #cd6892;
+}
+
+.caution:hover .tooltip-text {
+    visibility: visible;
+    opacity: 1;
+}
+
+.tooltip-text {
+    visibility: hidden;
+    position: absolute;
+    z-index: 1;
+    width: 500px;
+    margin-left: -100px;
+    padding: 5px 0;
+    font-size: 17px;
+    border: 2px solid #ffd54f;
+    border-radius: 4px;
+    background-color: #302e38;
+    bottom: 135%;
+    left: 50%;
+    opacity: 0;
+    transition: opacity 0.3s;
+}
+
+#toast-container {
+    position: absolute;
+    bottom: 20px;
+    right: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    z-index: 1000;
+}
+
+#toast-container > .toast {
+    width: 140px;
+    text-align: center;
+    background-color: #212121;
+    padding: 10px 16px;
+    border-radius: 6px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.3s, transform 0.3s;
+}
+
+#toast-container > .toast.show {
+    opacity: 1;
+    transform: translateY(0);
+}

--- a/download-options.html
+++ b/download-options.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="downloadOptions.js" type="module"></script>
+    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="download-options.css" />
+    <title>osu! preview</title>
+</head>
+
+<body class="download-options">
+    <h1 class="title">Beatmap provider</h1>
+    <div class="options-section">
+        <div>
+            <label for="osu">Official osu! website</label>
+            <input type="radio" id="osu" name="provider" value="osu">
+        </div>
+        <div>
+            <label for="nerinyan">NeriNyan (South Korea)</label>
+            <input type="radio" id="nerinyan" name="provider" value="nerinyan">
+        </div>
+        <div>
+            <label for="sayobot">Sayobot (China)</label>
+            <input type="radio" id="sayobot" name="provider" value="sayobot">
+        </div>
+        <div>
+            <label for="mino">Mino (Poland / Canada)</label>
+            <div class="btn-big pink caution">
+                !
+                <span class="tooltip-text">
+                    This provider doesn't support no-video downloads.<br>
+                    Beatmaps with videos may load more slowly.
+                </span>
+            </div>
+            <input type="radio" id="mino" name="provider" value="mino">
+        </div>
+        <div>
+            <label for="custom">Custom URL - replace beatmapset ID with {id}</label>
+            <input type="radio" id="custom" name="provider" value="custom">
+        </div>
+        <div>
+            <input type="text" id="custom-url-input" placeholder="https://example.com/{id}">
+        </div>
+    </div>
+    <button id="save-btn" class="btn-big blue">Save</button>
+    <div id="toast-container"></div>
+</body>
+
+</html>

--- a/downloadOptions.js
+++ b/downloadOptions.js
@@ -1,0 +1,81 @@
+const providerList = {
+    osu: "https://osu.ppy.sh/beatmapsets/{id}/download?noVideo=1",
+    nerinyan: "https://api.nerinyan.moe/d/{id}?nv=1",
+    sayobot: "https://dl.sayobot.cn/beatmaps/download/novideo/{id}",
+    mino: "https://catboy.best/d/{id}"
+};
+
+if (document.body.className === "download-options") {
+    window.addEventListener("load", async (e) => {
+        const { provider, urlTemplate } = await readDownloadOptions();
+        document.getElementById(provider).checked = true;
+
+        if (provider === "custom") {
+            document.getElementById("custom-url-input").value = urlTemplate;
+        }
+
+        document.getElementById("save-btn").addEventListener("click", saveDownloadOptions);
+    });
+}
+
+const saveDownloadOptions = () => {
+    const provider = document.querySelector("input[name='provider']:checked").value;
+    let urlTemplate;
+
+    if (provider === "custom") {
+        const customUrl = document.getElementById("custom-url-input").value.trim();
+
+        if (!customUrl.includes("{id}")) {
+            showToast("URL must include {id}.");
+            return;
+        }
+
+        if (!/^https?:\/\//i.test(customUrl)) {
+            urlTemplate = "https://" + customUrl;
+        }
+        else {
+            urlTemplate = customUrl;
+        }
+    }
+    else {
+        urlTemplate = providerList[provider];
+    }
+  
+    chrome.storage.local.set({ downloadOptions: { provider, urlTemplate } }, () => {
+        showToast("Saved!");
+    });
+};
+
+export const readDownloadOptions = async () => {
+    const savedDownloadOptions = (await chrome.storage.local.get("downloadOptions")).downloadOptions;
+    if (!savedDownloadOptions) {
+        const defaultOptions = {
+            provider: "osu",
+            urlTemplate: "https://osu.ppy.sh/beatmapsets/{id}/download?noVideo=1"
+        };
+        chrome.storage.local.set({ downloadOptions: defaultOptions });
+        return defaultOptions;
+    }
+    else {
+        return savedDownloadOptions;
+    }
+}
+
+function showToast(message, duration = 3000) {
+    const toastContainer = document.getElementById("toast-container");
+    const toast = document.createElement("div");
+    toast.className = "toast";
+    toast.textContent = message;
+
+    toastContainer.appendChild(toast);
+    void toast.offsetHeight;
+    toast.classList.add("show");
+
+    const hide = () => {
+        toast.classList.remove("show");
+        toast.addEventListener("transitionend", () => toast.remove(), { once: true });
+    };
+
+    setTimeout(hide, duration);
+}
+

--- a/loading.js
+++ b/loading.js
@@ -60,7 +60,7 @@ export const showDownloadOptionsBtn = () => {
         else {
             window.open(chrome.runtime.getURL("options.html"));
         }
-  });
+    });
 }
 
 export const error = (errText, showReportBtn) => {

--- a/loading.js
+++ b/loading.js
@@ -51,6 +51,18 @@ export const clearValue = () => {
     worker.postMessage(["setValue", null]);
 }
 
+export const showDownloadOptionsBtn = () => {
+    $("#loading-download-options-btn").style.display = "inline-block";
+    $("#loading-download-options-btn").addEventListener("click", e => {
+        if (chrome.runtime.openOptionsPage) {
+            chrome.runtime.openOptionsPage();
+        }
+        else {
+            window.open(chrome.runtime.getURL("options.html"));
+        }
+  });
+}
+
 export const error = (errText, showReportBtn) => {
     text.innerHTML = errText ?? "An error occured.";
     screen.classList.add("error");

--- a/manifest.json
+++ b/manifest.json
@@ -16,5 +16,9 @@
         "16": "/assets/icon16.png",
         "48": "/assets/icon48.png",
         "128": "/assets/icon128.png"
+    },
+    "options_ui": {
+        "page": "download-options.html",
+        "open_in_tab": true
     }
 }

--- a/popup.html
+++ b/popup.html
@@ -100,7 +100,10 @@
         <span id="loading-face">:(</span>
         <span id="loading-text"></span>
         <span id="loading-progress"></span>
-        <button id="loading-report-btn" class="btn-big blue report-btn">Report the error</button>
+        <div id="loading-btn-container">
+            <button id="loading-download-options-btn" class="btn-big blue">Download options</button>
+            <button id="loading-report-btn" class="btn-big blue report-btn">Report the error</button>
+        </div>
     </div>
     <img id="flashlight" src="assets/flashlight.png" class="hidden">
 </body>

--- a/popup.html
+++ b/popup.html
@@ -64,6 +64,7 @@
                         Upload skin
                     </label>
                     <button id="reset-skin-btn" class="btn-big red">Reset skin</button>
+                    <button id="download-options-btn" class="btn-big blue download-options-btn">Download options</button>
                 </div>
                 <div class="right">
                     <label id="check-cursor" class="checkbox">Show cursor</label>

--- a/popup.js
+++ b/popup.js
@@ -436,6 +436,14 @@ $("#reset-skin-btn").addEventListener("click", async e => {
 
     reloadModButtons();
 });
+$("#download-options-btn").addEventListener("click", e => {
+    if (chrome.runtime.openOptionsPage) {
+        chrome.runtime.openOptionsPage();
+    }
+    else {
+        window.open(chrome.runtime.getURL("options.html"));
+    }
+});
 $("#report-email-btn").addEventListener("click", e => {
     navigator.clipboard.writeText('technozamb19@gmail.com');
     alert('Author\'s email copied to the clipboard');

--- a/popup.js
+++ b/popup.js
@@ -4,6 +4,7 @@ import { ProgressBar } from "./progress.js";
 import * as loadingWidget from "/loading.js";
 import { volumes, updateSliders } from "/volumes.js";
 import { $, sleep } from "./functions.js";
+import { readDownloadOptions } from './downloadOptions.js';
 
 
 export let options = {
@@ -61,7 +62,9 @@ window.addEventListener("load", async (e) => {
             console.log("Beatmap not found in local storage; downloading it");
             loadingWidget.setText("downloading beatmap");
 
-            const downloadResult = await downloadMapset(`https://osu.ppy.sh/beatmapsets/${beatmapSetID}/download`);
+            const { urlTemplate } = await readDownloadOptions();
+            const url = urlTemplate.replaceAll("{id}", beatmapSetID);
+            const downloadResult = await downloadMapset(url);
             if (typeof downloadResult === "string") {
                 loadingWidget.clearValue();
                 loadingWidget.error(downloadResult);

--- a/popup.js
+++ b/popup.js
@@ -61,6 +61,7 @@ window.addEventListener("load", async (e) => {
         if (!storedMap) {
             console.log("Beatmap not found in local storage; downloading it");
             loadingWidget.setText("downloading beatmap");
+            loadingWidget.showDownloadOptionsBtn();
 
             const { urlTemplate } = await readDownloadOptions();
             const url = urlTemplate.replaceAll("{id}", beatmapSetID);

--- a/style.css
+++ b/style.css
@@ -457,7 +457,11 @@ footer {
     color: black;
     cursor: pointer;
 }
-
+.download-options-btn {
+    height: 38px;
+    font-size: 18px;
+    margin-top: 12px;
+}
 #repo-link, #repo-link:visited {
     color: white !important;
     text-decoration: none !important;

--- a/style.css
+++ b/style.css
@@ -539,13 +539,18 @@ footer {
     font-family: 'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, sans-serif;
     font-size: 38px;
 }
-#loading-report-btn {
-    width: 190px;
+#loading-btn-container {
+    display: flex;
+    justify-content: center;
+    gap: 16px;
     position: absolute;
     left: 50%;
     bottom: 0;
     margin-bottom: 24px;
     transform: translateX(-50%);
+}
+#loading-btn-container > button {
+    width: 190px;
     display: none;
 }
 


### PR DESCRIPTION
This PR improves download performance by introducing new download options.

### Changes:
- Use no-video downloads by default
- Allow users to choose beatmap mirrors instead of the official osu! website
- Enable changing the beatmap provider from the loading screen

These changes aim to reduce loading times and improve the user experience.

## Screenshots
<img width="800" height="600" alt="more-tab" src="https://github.com/user-attachments/assets/db922d57-2eed-4c9f-9137-39835a7555a6" />
<img width="800" height="373" alt="download-options-page" src="https://github.com/user-attachments/assets/d7aadc15-3827-4b59-bc91-515ace68f0f6" />

## Comparison

### Before

https://github.com/user-attachments/assets/9456fb5a-2447-41a4-983d-e4485187d98e

### After (NeriNyan)

https://github.com/user-attachments/assets/a10c15ff-51c9-4e99-8325-9e2b4465ce31